### PR TITLE
Update index.js

### DIFF
--- a/src/agenda/index.js
+++ b/src/agenda/index.js
@@ -135,7 +135,7 @@ export default class AgendaView extends Component {
   }
 
   setScrollPadPosition(y, animated) {
-    this.scrollPad.getNode().scrollTo({x: 0, y, animated});
+    this.scrollPad.scrollTo({x: 0, y, animated});
   }
 
   onScrollPadLayout() {


### PR DESCRIPTION
To support RN 62.0. To fix warning - 'Calling `getNode()` on the ref of an Animated component'